### PR TITLE
Fix implementation of fn every

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,12 +382,13 @@ With the union of concurrency and iteration, the sky is the limit.
 let every = fn(arr, check) {
   let passed = true;
   map(arr, fn(e) {
-    switch check(e) { case true: passed = false; } }
+    switch check(e) { case false: passed = false; } }
   )
   return passed;
 };
 
-result = every([5,2,4,1,3], fn(e) { return e >= 2 }); // false
+result1 = every([5,2,4,1,3], fn(e) { return e >= 2 }); // false
+result2 = every([5,2,4,1,3], fn(e) { return e >= 1 }); // true
 ```
 
 With this speed, your program's going to finish before you've even started writing it.


### PR DESCRIPTION
I think there is a typo in this example: the switch clause is wrong.
Check the code on an array of integers all greater than 2 and the result would be false as well.
https://github.com/jesseduffield/OK/blob/d150075b0824c6a5c4d45a599755da33b1e1ff8f/README.md?plain=1#L381-L391
